### PR TITLE
第6章 テスト不足に気づいたら

### DIFF
--- a/dollar.go
+++ b/dollar.go
@@ -2,24 +2,21 @@ package money
 
 // Dollar struct is the difinition of a US currency unit.
 type Dollar struct {
-	amount int
+	Money
 }
 
 // NewDollar is Dollar's constructor
-func NewDollar(amount int) *Dollar {
+func NewDollar(amounter int) *Dollar {
 	c := new(Dollar)
-	c.amount = amount
+	c.amounter = amounter
 	return c
 }
 
 // Times multiplies a Dollar amount by the specified value.
 func (d *Dollar) Times(multiplier int) *Dollar {
-	return NewDollar(d.amount * multiplier)
+	return NewDollar(d.amount() * multiplier)
 }
 
-// Equals determines that the value specified in the argument is equal to
-// the value of the receiver.
-// If they are equal, return true.
-func (d *Dollar) Equals(object *Dollar) bool {
-	return d.amount == object.amount
+func (d *Dollar) amount() int {
+	return d.amounter
 }

--- a/franc.go
+++ b/franc.go
@@ -2,24 +2,21 @@ package money
 
 // Franc struct is the difinition of a US currency unit.
 type Franc struct {
-	amount int
+	Money
 }
 
 // NewFranc is Franc's constructor
-func NewFranc(amount int) *Franc {
+func NewFranc(amounter int) *Franc {
 	c := new(Franc)
-	c.amount = amount
+	c.amounter = amounter
 	return c
 }
 
 // Times multiplies a Franc amount by the specified value.
 func (d *Franc) Times(multiplier int) *Franc {
-	return NewFranc(d.amount * multiplier)
+	return NewFranc(d.amount() * multiplier)
 }
 
-// Equals determines that the value specified in the argument is equal to
-// the value of the receiver.
-// If they are equal, return true.
-func (d *Franc) Equals(object *Franc) bool {
-	return d.amount == object.amount
+func (d *Franc) amount() int {
+	return d.amounter
 }

--- a/money.go
+++ b/money.go
@@ -1,0 +1,22 @@
+package money
+
+// Money is a Dollar, Franc, or other base struct.
+type Money struct {
+	amounter int
+}
+
+// Moneyable is a Dollar, Franc, or other base interface.
+type Moneyable interface {
+	amount() int
+}
+
+func (d *Money) amount() int {
+	return d.amounter
+}
+
+// Equals determines that the value specified in the argument is equal to
+// the value of the receiver.
+// If they are equal, return true.
+func (d *Money) Equals(money Moneyable) bool {
+	return d.amount() == money.amount()
+}

--- a/money_test.go
+++ b/money_test.go
@@ -36,6 +36,22 @@ func TestEquality(t *testing.T) {
 	if expected != result {
 		t.Errorf("Dollar(%v)#Equals(%v) = %v, want %v", 5, in, result, expected)
 	}
+
+	in = 5
+	expected = true
+	var resultFranc = five.Equals(NewFranc(in))
+
+	if expected != resultFranc {
+		t.Errorf("Franc(%v)#Equals(%v) = %v, want %v", 5, in, resultFranc, expected)
+	}
+
+	in = 6
+	expected = false
+	resultFranc = five.Equals(NewFranc(in))
+
+	if expected != resultFranc {
+		t.Errorf("Franc(%v)#Equals(%v) = %v, want %v", 5, in, resultFranc, expected)
+	}
 }
 
 func TestFrancMultiplication(t *testing.T) {


### PR DESCRIPTION
Golang では実装継承ができないため、`#amount()` をメソッドにし、 interface によるダックタイピングで一旦 '#Equals' を共通化した。

c.f. https://qiita.com/tenntenn/items/e04441a40aeb9c31dbaf

'#amount()' は Dollar, Franc, Money で重複しているため、今後どこかで重複を排除する必要がある。