### PR TITLE
第7章 疑念をテストに翻訳する

### DIFF
--- a/dollar.go
+++ b/dollar.go
@@ -6,17 +6,14 @@ type Dollar struct {
 }
 
 // NewDollar is Dollar's constructor
-func NewDollar(amounter int) *Dollar {
+func NewDollar(amount int) *Dollar {
 	c := new(Dollar)
-	c.amounter = amounter
+	c.amount = amount
+	c.name = "Dollar"
 	return c
 }
 
 // Times multiplies a Dollar amount by the specified value.
 func (d *Dollar) Times(multiplier int) *Dollar {
-	return NewDollar(d.amount() * multiplier)
-}
-
-func (d *Dollar) amount() int {
-	return d.amounter
+	return NewDollar(d.amount * multiplier)
 }

--- a/franc.go
+++ b/franc.go
@@ -6,17 +6,14 @@ type Franc struct {
 }
 
 // NewFranc is Franc's constructor
-func NewFranc(amounter int) *Franc {
+func NewFranc(amount int) *Franc {
 	c := new(Franc)
-	c.amounter = amounter
+	c.amount = amount
+	c.name = "Franc"
 	return c
 }
 
 // Times multiplies a Franc amount by the specified value.
 func (d *Franc) Times(multiplier int) *Franc {
-	return NewFranc(d.amount() * multiplier)
-}
-
-func (d *Franc) amount() int {
-	return d.amounter
+	return NewFranc(d.amount * multiplier)
 }

--- a/money.go
+++ b/money.go
@@ -2,21 +2,28 @@ package money
 
 // Money is a Dollar, Franc, or other base struct.
 type Money struct {
-	amounter int
+	amount int
+	name   string
 }
 
 // Moneyable is a Dollar, Franc, or other base interface.
 type Moneyable interface {
-	amount() int
+	getAmount() int
+	getName() string
 }
 
-func (d *Money) amount() int {
-	return d.amounter
+func (d *Money) getAmount() int {
+	return d.amount
+}
+
+func (d *Money) getName() string {
+	return d.name
 }
 
 // Equals determines that the value specified in the argument is equal to
 // the value of the receiver.
 // If they are equal, return true.
-func (d *Money) Equals(money Moneyable) bool {
-	return d.amount() == money.amount()
+func (d *Money) Equals(object interface{}) bool {
+	var money = object.(Moneyable)
+	return d.amount == money.getAmount() && d.name == money.getName()
 }

--- a/money_test.go
+++ b/money_test.go
@@ -19,38 +19,34 @@ func TestMultiplication(t *testing.T) {
 }
 
 func TestEquality(t *testing.T) {
-	var five = NewDollar(5)
+	var result = NewDollar(5).Equals(NewDollar(5))
 
-	var in = 5
-	var expected = true
-	var result = five.Equals(NewDollar(in))
-
-	if expected != result {
-		t.Errorf("Dollar(%v)#Equals(%v) = %v, want %v", 5, in, result, expected)
+	if !result {
+		t.Errorf("Dollar(%v)#Equals(%v) = %v, want %v", 5, 5, result, true)
 	}
 
-	in = 6
-	expected = false
-	result = five.Equals(NewDollar(in))
+	result = NewDollar(5).Equals(NewDollar(6))
 
-	if expected != result {
-		t.Errorf("Dollar(%v)#Equals(%v) = %v, want %v", 5, in, result, expected)
+	if result {
+		t.Errorf("Dollar(%v)#Equals(%v) = %v, want %v", 5, 6, result, false)
 	}
 
-	in = 5
-	expected = true
-	var resultFranc = five.Equals(NewFranc(in))
+	result = NewFranc(5).Equals(NewFranc(5))
 
-	if expected != resultFranc {
-		t.Errorf("Franc(%v)#Equals(%v) = %v, want %v", 5, in, resultFranc, expected)
+	if !result {
+		t.Errorf("Franc(%v)#Equals(%v) = %v, want %v", 5, 5, result, true)
 	}
 
-	in = 6
-	expected = false
-	resultFranc = five.Equals(NewFranc(in))
+	result = NewFranc(5).Equals(NewFranc(6))
 
-	if expected != resultFranc {
-		t.Errorf("Franc(%v)#Equals(%v) = %v, want %v", 5, in, resultFranc, expected)
+	if result {
+		t.Errorf("Franc(%v)#Equals(%v) = %v, want %v", 5, 6, result, false)
+	}
+
+	result = NewFranc(5).Equals(NewDollar(5))
+
+	if result {
+		t.Errorf("Franc(%v)#Equals(Dollar(%v)) = %v, want %v", 5, 5, result, false)
 	}
 }
 


### PR DESCRIPTION
Franc と Dollar を比較した場合にエラーとするように、 Equals() メソッドを修正した。

Java の getClass() に相当するメソッドがないため、メンバー変数 name を用意して、初期作成時のクラス名を保存しておき、比較時にチェックできるようにした。

コードを整理している中で Moneyable インタフェースに宣言しているアクセサを Dollar, Franc が実装していないのに変換できたり、*Money レシーバに対して *Dollar, *Franc から呼び出せる理由がわからないのだが、これらについては継続調査する。